### PR TITLE
feature/refactor-abstract-repository

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ vendor
 docker.sh
 .phpunit.result.cache
 .idea
+/phpunit.xml.dist

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit backupGlobals="false"
+         backupStaticAttributes="false"
+         colors="true"
+         convertErrorsToExceptions="true"
+         convertNoticesToExceptions="true"
+         convertWarningsToExceptions="true"
+         processIsolation="false"
+         stopOnFailure="false">
+    <testsuites>
+        <testsuite name="Package Test Suite">
+            <directory suffix="Test.php">./tests</directory>
+        </testsuite>
+    </testsuites>
+    <filter>
+        <whitelist processUncoveredFilesFromWhitelist="true">
+            <directory suffix=".php">./src</directory>
+            <exclude>
+                <directory suffix=".php">./src/Integration/Laravel/config</directory>
+                <directory suffix=".php">./src/Externals</directory>
+            </exclude>
+        </whitelist>
+    </filter>
+    <php>
+        <env name="APP_ENV" value="testing"/>
+    </php>
+</phpunit>

--- a/src/AbstractEloquentRepository.php
+++ b/src/AbstractEloquentRepository.php
@@ -6,13 +6,13 @@ namespace Unostentatious\Repository;
 use Illuminate\Database\Eloquent\Model;
 use Unostentatious\Repository\Interfaces\ConnectionRepositoryInterface;
 
-abstract class AbstractUnostentatiousRepository implements ConnectionRepositoryInterface
+abstract class AbstractEloquentRepository implements ConnectionRepositoryInterface
 {
     /** @var \Illuminate\Database\Eloquent\Model $model */
     protected Model $model;
 
     /**
-     * AbstractUnostentatiousRepository constructor.
+     * AbstractEloquentRepository constructor.
      *
      * @throws \ReflectionException
      *
@@ -163,6 +163,8 @@ abstract class AbstractUnostentatiousRepository implements ConnectionRepositoryI
      * Set the selected model.
      *
      * @param \Illuminate\Database\Eloquent\Model $model
+     *
+     * @return void
      */
     private function setModel(Model $model): void
     {

--- a/src/Externals/Exceptions/AbstractBaseException.php
+++ b/src/Externals/Exceptions/AbstractBaseException.php
@@ -1,0 +1,43 @@
+<?php
+declare(strict_types=1);
+
+namespace Unostentatious\Repository\Externals\Exceptions;
+
+use Exception;
+use Throwable;
+use Unostentatious\Repository\Externals\Interfaces\BaseExceptionInterface;
+
+abstract class AbstractBaseException extends Exception implements BaseExceptionInterface
+{
+    /**
+     * @var mixed[]
+     */
+    protected array $messageParams;
+
+    /**
+     * BaseException constructor.
+     *
+     * @param null|string $message
+     * @param null|mixed[] $messageParameters
+     * @param null|int $code
+     * @param \Throwable|null $previous
+     */
+    public function __construct(
+        ?string $message = null,
+        ?array $messageParameters = null,
+        ?int $code = null,
+        ?Throwable $previous = null
+    ) {
+        parent::__construct($message ?? '', $code ?? 0, $previous);
+        
+        $this->messageParams = $messageParameters ?? [];
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function getMessageParameters(): array
+    {
+        return $this->messageParams;
+    }
+}

--- a/src/Externals/Interfaces/BaseExceptionInterface.php
+++ b/src/Externals/Interfaces/BaseExceptionInterface.php
@@ -1,0 +1,96 @@
+<?php
+declare(strict_types=1);
+
+namespace Unostentatious\Repository\Externals\Interfaces;
+
+interface BaseExceptionInterface
+{
+    /**
+     * Default error code for conflict.
+     *
+     * @const int
+     */
+    public const DEFAULT_ERROR_CODE_CONFLICT = 1500;
+    /**
+     * Default error code for critical.
+     *
+     * @const int
+     */
+    public const DEFAULT_ERROR_CODE_CRITICAL = 9000;
+    /**
+     * Default error code for forbidden.
+     *
+     * @const int
+     */
+    public const DEFAULT_ERROR_CODE_FORBIDDEN = 1300;
+
+    /**
+     * Default error code for not found.
+     *
+     * @const int
+     */
+    public const DEFAULT_ERROR_CODE_NOT_FOUND = 1400;
+
+    /**
+     * Default error code for runtime.
+     *
+     * @const int
+     */
+    public const DEFAULT_ERROR_CODE_RUNTIME = 1100;
+
+    /**
+     * Default error code for validation.
+     *
+     * @const int
+     */
+    public const DEFAULT_ERROR_CODE_VALIDATION = 1000;
+
+    /**
+     * Default error sub-code.
+     *
+     * @const int
+     */
+    public const DEFAULT_ERROR_SUB_CODE = 0;
+    /**
+     * Default status code for conflict.
+     *
+     * @const int
+     */
+    public const DEFAULT_STATUS_CODE_CONFLICT = 409;
+    /**
+     * Default status code for critical.
+     *
+     * @const int
+     */
+    public const DEFAULT_STATUS_CODE_CRITICAL = 500;
+    /**
+     * Default status code for forbidden.
+     *
+     * @const int
+     */
+    public const DEFAULT_STATUS_CODE_FORBIDDEN = 403;
+    /**
+     * Default status code for not found.
+     *
+     * @const int
+     */
+    public const DEFAULT_STATUS_CODE_NOT_FOUND = 404;
+    /**
+     * Default status code for runtime.
+     *
+     * @const int
+     */
+    public const DEFAULT_STATUS_CODE_RUNTIME = 500;
+    /**
+     * Default status code for unauthorized.
+     *
+     * @const int
+     */
+    public const DEFAULT_STATUS_CODE_UNAUTHORIZED = 401;
+    /**
+     * Default status code for validation.
+     *
+     * @const int
+     */
+    public const DEFAULT_STATUS_CODE_VALIDATION = 400;
+}

--- a/src/Integration/Laravel/Exceptions/IncorrectClassStructureException.php
+++ b/src/Integration/Laravel/Exceptions/IncorrectClassStructureException.php
@@ -3,10 +3,32 @@ declare(strict_types=1);
 
 namespace Unostentatious\Repository\Integration\Laravel\Exceptions;
 
-use Exception;
+use Unostentatious\Repository\Externals\Exceptions\AbstractBaseException;
 use Unostentatious\Repository\Interfaces\UnostentatiousRepositoryExceptionInterface;
 
-final class IncorrectClassStructureException extends Exception implements UnostentatiousRepositoryExceptionInterface
+final class IncorrectClassStructureException extends AbstractBaseException implements UnostentatiousRepositoryExceptionInterface
 {
-    // Body not needed.
+    /**
+     * @inheritDoc
+     */
+    public function getErrorCode(): int
+    {
+        return self::DEFAULT_ERROR_CODE_CRITICAL;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getErrorSubCode(): int
+    {
+        return self::DEFAULT_ERROR_SUB_CODE;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getStatusCode(): int
+    {
+        return self::DEFAULT_STATUS_CODE_CRITICAL;
+    }
 }

--- a/src/Interfaces/UnostentatiousRepositoryExceptionInterface.php
+++ b/src/Interfaces/UnostentatiousRepositoryExceptionInterface.php
@@ -5,5 +5,24 @@ namespace Unostentatious\Repository\Interfaces;
 
 interface UnostentatiousRepositoryExceptionInterface
 {
-    // Body not needed.
+    /**
+     * Return the error code.
+     *
+     * @return int
+     */
+    public function getErrorCode(): int;
+
+    /**
+     * Return the error sub-code.
+     *
+     * @return int
+     */
+    public function getErrorSubCode(): int;
+
+    /**
+     * Return the error response status code.
+     *
+     * @return int
+     */
+    public function getStatusCode(): int;
 }

--- a/tests/AbstractApplicationTestCase.php
+++ b/tests/AbstractApplicationTestCase.php
@@ -5,6 +5,9 @@ namespace Unostentatious\Repository\Tests;
 
 use Laravel\Lumen\Application;
 
+/**
+ * @covers nothing
+ */
 abstract class AbstractApplicationTestCase extends AbstractTestCase
 {
     /**

--- a/tests/AbstractEloquentRepositoryTest.php
+++ b/tests/AbstractEloquentRepositoryTest.php
@@ -10,7 +10,10 @@ use Mockery\MockInterface;
 use Unostentatious\Repository\Tests\Stubs\ModelStub;
 use Unostentatious\Repository\Tests\Stubs\RepositoryStub;
 
-final class AbstractUnostentatiousRepositoryTest extends AbstractTestCase
+/**
+ * @covers \Unostentatious\Repository\AbstractEloquentRepository
+ */
+final class AbstractEloquentRepositoryTest extends AbstractTestCase
 {
     /**
      * Assert that the repository's all() method returns an array type.

--- a/tests/AbstractTestCase.php
+++ b/tests/AbstractTestCase.php
@@ -7,6 +7,9 @@ use Mockery;
 use Mockery\LegacyMockInterface;
 use PHPUnit\Framework\TestCase;
 
+/**
+ * @covers nothing
+ */
 abstract class AbstractTestCase extends TestCase
 {
     /**

--- a/tests/Integration/Laravel/Exceptions/IncorrectClassStructureExceptionTest.php
+++ b/tests/Integration/Laravel/Exceptions/IncorrectClassStructureExceptionTest.php
@@ -1,0 +1,28 @@
+<?php
+declare(strict_types=1);
+
+namespace Unostentatious\Repository\Tests\Integration\Laravel\Exceptions;
+
+use Unostentatious\Repository\Externals\Exceptions\AbstractBaseException;
+use Unostentatious\Repository\Integration\Laravel\Exceptions\IncorrectClassStructureException;
+use Unostentatious\Repository\Tests\AbstractTestCase;
+
+/**
+ * @covers \Unostentatious\Repository\Integration\Laravel\Exceptions\IncorrectClassStructureException
+ */
+final class IncorrectClassStructureExceptionTest extends AbstractTestCase
+{
+    /**
+     * Test exception error codes.
+     *
+     * @return void
+     */
+    public function testErrorCodes(): void
+    {
+        $exception = new IncorrectClassStructureException();
+
+        self::assertEquals(AbstractBaseException::DEFAULT_ERROR_CODE_CRITICAL, $exception->getErrorCode());
+        self::assertEquals(AbstractBaseException::DEFAULT_ERROR_SUB_CODE, $exception->getErrorSubCode());
+        self::assertEquals(AbstractBaseException::DEFAULT_STATUS_CODE_CRITICAL, $exception->getStatusCode());
+    }
+}

--- a/tests/Integration/Laravel/UnostentatiousRepositoryProviderTest.php
+++ b/tests/Integration/Laravel/UnostentatiousRepositoryProviderTest.php
@@ -10,6 +10,9 @@ use Unostentatious\Repository\Tests\AbstractApplicationTestCase;
 use Unostentatious\Repository\Tests\Integration\Laravel\Stubs\Classes\Interfaces\RepositoryStubInterface;
 use Unostentatious\Repository\Tests\Integration\Laravel\Stubs\Classes\RepositoryStub;
 
+/**
+ * @covers \Unostentatious\Repository\Integration\Laravel\UnostentatiousRepositoryProvider
+ */
 final class UnostentatiousRepositoryProviderTest extends AbstractApplicationTestCase
 {
     /**

--- a/tests/Stubs/RepositoryStub.php
+++ b/tests/Stubs/RepositoryStub.php
@@ -3,9 +3,9 @@ declare(strict_types=1);
 
 namespace Unostentatious\Repository\Tests\Stubs;
 
-use Unostentatious\Repository\AbstractUnostentatiousRepository;
+use Unostentatious\Repository\AbstractEloquentRepository;
 
-class RepositoryStub extends AbstractUnostentatiousRepository
+class RepositoryStub extends AbstractEloquentRepository
 {
 
     /**


### PR DESCRIPTION
- Renamed `AbstractUnostentatiousRepository` to `AbstractEloquentRepository` due to it's specificity to Eloquent implementation
- Added phpunit.xml for default configuration during test
- Excluded `/config` directory for code coverage
- Added temporary `External` directory containing utils and helpers that
will be moved to a separate package on next release